### PR TITLE
Path changed: first the icestorm tools are search in the apio local p…

### DIFF
--- a/apio/__init__.py
+++ b/apio/__init__.py
@@ -10,7 +10,10 @@ from os.path import join, expanduser
 
 package_dir = join(expanduser("~"), '.platformio/packages/')
 scons_dir = join(package_dir, 'tool-scons', 'script', 'scons')
-os.environ['PATH'] = os.environ['PATH'] + ":" + join(package_dir, 'toolchain-icestorm', 'bin')
+
+# -- Give the priority to the packages installed by apio
+os.environ['PATH'] = (join(package_dir, 'toolchain-icestorm', 'bin') +
+                      ":" + os.environ['PATH'])
 
 
 @click.group()


### PR DESCRIPTION
…ackage folder. If not found, the system path is used