### PR TITLE
Allow Apio to work in Python 3 virtual environments

### DIFF
--- a/apio/__init__.py
+++ b/apio/__init__.py
@@ -49,24 +49,24 @@ def uninstall():
 
 @cli.command('clean')
 def clean():
-    subprocess.call(['python', scons_path, '-c'])
+    subprocess.call(['python2', scons_path, '-c'])
 
 
 @cli.command('build')
 def build():
-    subprocess.call(['python', scons_path])
+    subprocess.call(['python2', scons_path])
 
 
 @cli.command('upload')
 def upload():
-    subprocess.call(['python', scons_path, 'upload'])
+    subprocess.call(['python2', scons_path, 'upload'])
 
 
 @cli.command('time')
 def time():
-    subprocess.call(['python', scons_path, 'time'])
+    subprocess.call(['python2', scons_path, 'time'])
 
 
 @cli.command('sim')
 def sim():
-    subprocess.call(['python', scons_path, 'sim'])
+    subprocess.call(['python2', scons_path, 'sim'])


### PR DESCRIPTION
SCons only works with Python 2. Instead of using the `python` alias, which may or may not be Python 2 in the system and will definitely not be Python 2 if the user is working in a Python 3 virtual environment, force Apio to use `python2`.